### PR TITLE
Fix type mismatch in example config.

### DIFF
--- a/.twig_cs-enhanced.example.php
+++ b/.twig_cs-enhanced.example.php
@@ -19,8 +19,8 @@ $finder = Finder::create()
     ->name('*.html');
 
 return new Config([$finder], [
-    'indent' => '7',
-    'innerIndent' => '3',
+    'indent' => 7,
+    'innerIndent' => 3,
     'rules' => [
         IndentFixer::getRuleName() => false,
         PipePrefixSpacingFixer::getRuleName() => true,


### PR DESCRIPTION
Config::getIndent() must return an int